### PR TITLE
Update nwc-convert to use path configuration and new folder structure

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MESSAGES CONTROL]
+
+# Disable specific warnings
+disable=
+    f-string-without-interpolation  # W1309: Allow f-strings without interpolation

--- a/pathconfig.py
+++ b/pathconfig.py
@@ -13,23 +13,27 @@ from typing import Optional
 class PathConfig:
     """Container for path configuration settings."""
 
-    def __init__(self, input_folder: str, output_folder: str, audio_output_folder: str):
+    def __init__(self, input_folder: str, output_folder: str, audio_output_folder: str,
+                 soundfont_path: Optional[str] = None):
         """Initialize PathConfig with folder paths.
 
         Args:
             input_folder: Path to input folder (relative or absolute)
             output_folder: Path to output folder (relative or absolute)
-            audio_output_folder: Path to temporary folder (relative or absolute)
+            audio_output_folder: Path to audio output folder (relative or absolute)
+            soundfont_path: Path to soundfont file (optional, relative or absolute)
         """
         self.input_folder = input_folder
         self.output_folder = output_folder
         self.audio_output_folder = audio_output_folder
+        self.soundfont_path = soundfont_path
 
     def __repr__(self) -> str:
         """Return string representation of configuration."""
         return (f"PathConfig(input_folder='{self.input_folder}', "
                 f"output_folder='{self.output_folder}', "
-                f"audio_output_folder='{self.audio_output_folder}')")
+                f"audio_output_folder='{self.audio_output_folder}', "
+                f"soundfont_path='{self.soundfont_path}')")
 
 
 def _load_jsonc(filepath: Path) -> dict:
@@ -134,7 +138,10 @@ def load_path_config(config_file: Optional[Path] = None) -> PathConfig:
         print(f"   Required fields: input_folder, output_folder, audio_output_folder")
         sys.exit(1)
 
-    return PathConfig(input_folder, output_folder, audio_output_folder)
+    # Extract optional fields
+    soundfont_path = data.get('soundfont_path', None)
+
+    return PathConfig(input_folder, output_folder, audio_output_folder, soundfont_path)
 
 
 def resolve_path(base_path: str, config_dir: Path) -> Path:

--- a/paths.jsonc
+++ b/paths.jsonc
@@ -21,5 +21,10 @@
 
     // Destination folder for label track, .mid, .wav and .flac files
     // Default: "c:/temp" on Windows, "/tmp" on Linux/Mac
-    "audio_output_folder": "c:/temp"
+    "audio_output_folder": "c:/temp",
+
+    // Path to FluidSynth soundfont file (.sf2)
+    // Can be absolute path or just filename (will default to current folder if no path)
+    // Default: "FluidR3_GM_GS.sf2" (looks in current folder)
+    "soundfont_path": "FluidR3_GM_GS.sf2"
 }


### PR DESCRIPTION
- Added soundfont_path to paths.jsonc configuration
- Updated pathconfig.py to load soundfont_path as optional field
- Refactored nwc-convert.py:
  * Added pathconfig imports and integration
  * Updated get_input_file_path to use output_folder (reads concatenated files)
  * Changed --out default to use audio_output_folder from config
  * Changed --soundfont default to use soundfont_path from config
  * Improved docstrings following pylint best practices
  * Removed all trailing whitespace
- Created .pylintrc to suppress W1309 (f-string-without-interpolation)
- Scripts now work seamlessly with song-based folder structure