### PR TITLE
Update lt-generate to use per-song configuration files

### DIFF
--- a/lt-generate.py
+++ b/lt-generate.py
@@ -34,13 +34,18 @@ from pathconfig import load_path_config, resolve_path, validate_file_exists
 # with measurenumbers and without. So the multiple output pdf's on
 # a single call to this method only happens if a song has multiple transpositions.
 def compile_tex_file(
-    configurations:list[ConfigItem], songtitle, input_folder, cleanup=True, engine='pdflatex',
+    songtitle, input_folder, cleanup=True, engine='pdflatex',
     show_measures=False, show_chords=False, show_tabs=False, tab_orientation='left'):
 
     # ***  Verify .tex file exists ***
     tex_file = input_folder / songtitle / f"{songtitle}.tex"
     if not validate_file_exists(tex_file, f"LaTeX file for '{songtitle}'"):
         return False
+
+    # ***  Load song-specific configuration ***
+    song_folder = input_folder / songtitle
+    lt_config_file = song_folder / "lt-config.jsonc"
+    configurations = ConfigLoader.load_from_file_optional(lt_config_file)
 
     # ***  Read .tex file  ***
     with open(tex_file, 'r', encoding='utf-8') as f:
@@ -429,32 +434,28 @@ def main():
     # in the list of lines that start with "success = ..." below.
     only = args.only
 
-    # ***  Read .json configuration file  ***
-    lt_config_file = input_folder.parent / "lt-config.jsonc"
-    configurations = ConfigLoader.load_from_file(lt_config_file)
-
     success = 0
     structuur_success = 0
 
     if only < 2:
         # generate liedtekst pdf
-        success = sum(compile_tex_file(configurations, f, input_folder, not args.no_cleanup, args.engine) for f in songtitles)
+        success = sum(compile_tex_file(f, input_folder, not args.no_cleanup, args.engine) for f in songtitles)
 
     if only == 2 or only == 0:
         # generate liedtekst pdf with measurenumbers
-        success = success + sum(compile_tex_file(configurations, f, input_folder, not args.no_cleanup, args.engine, show_measures=True) for f in songtitles)
+        success = success + sum(compile_tex_file(f, input_folder, not args.no_cleanup, args.engine, show_measures=True) for f in songtitles)
 
     if only == 3 or only == 0:
         # generate liedtekst pdf with chords
-        success = success + sum(compile_tex_file(configurations, f, input_folder, not args.no_cleanup, args.engine, show_measures=False, show_chords=True) for f in songtitles)
+        success = success + sum(compile_tex_file(f, input_folder, not args.no_cleanup, args.engine, show_measures=False, show_chords=True) for f in songtitles)
 
     if only == 4 or only == 0:
         # generate liedtekst pdf with measurenumbers and chords
-        success = success + sum(compile_tex_file(configurations, f, input_folder, not args.no_cleanup, args.engine, show_measures=True, show_chords=True) for f in songtitles)
+        success = success + sum(compile_tex_file(f, input_folder, not args.no_cleanup, args.engine, show_measures=True, show_chords=True) for f in songtitles)
 
     if only == 5 or only == 0:
         # generate liedtekst pdf with measurenumbers, chords and guitartabs
-        success = success + sum(compile_tex_file(configurations, f, input_folder, not args.no_cleanup, args.engine, show_measures=True, show_chords=True, show_tabs=True, tab_orientation=tab_orientation) for f in songtitles)
+        success = success + sum(compile_tex_file(f, input_folder, not args.no_cleanup, args.engine, show_measures=True, show_chords=True, show_tabs=True, tab_orientation=tab_orientation) for f in songtitles)
 
     # Generate structuur PDF for each liedtekst
     print("\n" + "="*60)

--- a/lt_configloader.py
+++ b/lt_configloader.py
@@ -29,12 +29,24 @@ class ConfigItem:
     action: Action
 
 class ConfigLoader:
-    """Dada"""
+    """Configuration loader for song-specific settings."""
+
     @staticmethod
     def load_from_file(filepath: str | Path) -> list[ConfigItem]:
-        """Leest JSON-configuratie in en parsed naar ConfigItem objecten."""
+        """Load JSON configuration and parse to ConfigItem objects.
+
+        Args:
+            filepath: Path to the configuration file
+
+        Returns:
+            List of ConfigItem objects
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist
+            Various exceptions for invalid JSON or config structure
+        """
         with open(filepath, 'r', encoding='utf-8') as f:
-            data = commentjson.load(f)  
+            data = commentjson.load(f)
 
         config_items = []
         for item in data:
@@ -54,6 +66,21 @@ class ConfigLoader:
                 description=description, condition=condition, action=action))
 
         return config_items
+
+    @staticmethod
+    def load_from_file_optional(filepath: str | Path) -> list[ConfigItem]:
+        """Load JSON configuration, returning empty list if file doesn't exist.
+
+        Args:
+            filepath: Path to the configuration file
+
+        Returns:
+            List of ConfigItem objects, or empty list if file doesn't exist
+        """
+        if not Path(filepath).exists():
+            return []
+
+        return ConfigLoader.load_from_file(filepath)
 
 
 def get_config(configs: list[ConfigItem], lied_id: int,


### PR DESCRIPTION
- Each song folder now has its own lt-config.jsonc file
- Added ConfigLoader.load_from_file_optional() for graceful handling of missing configs
- Updated compile_tex_file() to load config from song folder, not global location
- Removed global config loading from main()
- Config files are now optional - script works without them
- Removed all parent folder assumptions and hardcoded paths
- Updated docstrings following best practices