### PR TITLE
Update lt-upload to upload PDFs from _dist folder

### DIFF
--- a/lt-upload.ps1
+++ b/lt-upload.ps1
@@ -18,7 +18,7 @@
 
 
 #   P R O D U C T I O N:    move all pdf's to PDrive    (use --dry-run to test)
-rclone moveto '.' ProtonDrive:'Creatie/Muziek/Uploads/' --progress --filter-from lt-upload-filter.txt 
+rclone moveto '../_dist' ProtonDrive:'Creatie/Muziek/Uploads/' --progress --filter-from lt-upload-filter.txt 
 
 
 #   E X A M P L E:   move single file to PDrive


### PR DESCRIPTION
Changed the source directory from current directory to ../_dist to match the configured output_folder where lt-generate now outputs all generated PDFs.